### PR TITLE
Source files added to groups in VS projects

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -89,6 +89,27 @@ if(MSVC)
     endmacro()
 
     SET_OUTPUT_DIR_PROPERTY(vsg "")
+
+    # place source files into group folders
+    function(ASSIGN_SOURCE_GROUPS GROUP_NAME ROOT_FOLDER)
+        foreach(FILE IN ITEMS ${ARGN})
+            if (IS_ABSOLUTE "${FILE}")
+                file(RELATIVE_PATH RELATIVE_SOURCE "${ROOT_FOLDER}" "${FILE}")
+            else()
+                set(RELATIVE_SOURCE "${FILE}")
+            endif()
+            get_filename_component(SOURCE_PATH "${RELATIVE_SOURCE}" PATH)
+            string(REPLACE "/" "\\" SOURCE_PATH_MSVC "${SOURCE_PATH}")
+            source_group("${GROUP_NAME}\\${SOURCE_PATH_MSVC}" FILES "${FILE}")
+        endforeach()
+    endfunction(ASSIGN_SOURCE_GROUPS)
+        
+    # enable folders for MSVC
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+    # group source files and headers
+    ASSIGN_SOURCE_GROUPS("Source Files" "${CMAKE_CURRENT_SOURCE_DIR}" ${SOURCES})
+    ASSIGN_SOURCE_GROUPS("Header Files" "${CMAKE_SOURCE_DIR}/include/vsg" ${HEADERS})
 endif()
 
 # set up versions and position independent code that is required for unices

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -12,8 +12,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/viewer/Window.h>
 
-#include <vsg/vk/CommandVisitor.h>
-
 #include <array>
 #include <chrono>
 #include <iostream>


### PR DESCRIPTION
# Pull Request Template

## Description

Added function to place source and header files into folder groups when targeting MSVC. 
Also removed depreciated include in Window.cpp

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran CMake to generate Visual Studio Project
