### PR TITLE
Fixed "'Data' defined as a struct here but previously declared as a c…

### DIFF
--- a/include/vsg/traversals/DispatchTraversal.h
+++ b/include/vsg/traversals/DispatchTraversal.h
@@ -45,7 +45,7 @@ namespace vsg
         void apply(const Command& command);
 
     protected:
-        class Data;
+        struct Data;
         Data* _data;
     };
 } // namespace vsg


### PR DESCRIPTION
…lass" warning

Fix for "'Data' defined as a struct here but previously declared as a class" shown on Mac using clang v 10.0.0 (clang-1000.11.45.5)

## Description

While trying to compile and to run the prototype and the examples on Mac, I noticed the above mentioned warning (there are no other warnings/errors on Mac using clang v 10.0.0 so far).

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Executed following tests using `bash`:
```bash
-rwxr-xr-x  1 ...  239652 Nov 13 13:40 vsgallocator
-rwxr-xr-x  1 ...  251480 Nov 13 13:40 vsgarrays
-rwxr-xr-x  1 ...  359176 Nov 13 13:40 vsgc_interface
-rwxr-xr-x  1 ...  355040 Nov 13 13:40 vsgintrospection
-rwxr-xr-x  1 ...  191340 Nov 13 13:40 vsgmaths
-rwxr-xr-x  1 ...  224816 Nov 13 13:40 vsgmemory
-rwxr-xr-x  1 ...    8720 Nov 13 13:40 vsgnamespaces
-rwxr-xr-x  1 ...  182736 Nov 13 13:40 vsgpointer
-rwxr-xr-x  1 ...   70088 Nov 13 13:40 vsgtypes
-rwxr-xr-x  1 ...  198520 Nov 13 13:40 vsgvalues
-rwxr-xr-x  1 ...  332732 Nov 13 13:40 vsgvisitor
```

**Test Configuration**:
* Hardware: MacBook Pro
* Toolchain: cmake + MoltenVK + Xcode
* SDK: MotenVK

## Checklist:
- My code follows the style guidelines of this project
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
