### PR TITLE
Fix build error on macOS in Viewer::pollEvents() calling apply methods

### DIFF
--- a/include/vsg/ui/UIEvent.h
+++ b/include/vsg/ui/UIEvent.h
@@ -33,4 +33,10 @@ namespace vsg
     };
 
     using Events = std::list<ref_ptr<UIEvent>>;
+    
+    template<typename T>
+    std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
+    {
+        return stream << static_cast<typename std::underlying_type<T>::type>(e);
+    }
 } // namespace vsg


### PR DESCRIPTION
Compiling on macOS v10.13.6, using clang version Apple LLVM version 10.0.0 (clang-1000.11.45.5)

There is a compiler error in all `apply()`-methods in `Viewer::pollEvents()` dealing with enum classes:

```
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/src/vsg/viewer/Viewer.cpp:13:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/viewer/Viewer.h:15:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/viewer/Window.h:17:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/ui/UIEvent.h:15:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/core/Inherit.h:15:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/core/Allocator.h:20:
In file included from /Users/oleg/dev/osg-vulkan/vsg/src/include/vsg/io/stream.h:20:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/istream:163:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:208:20: note: candidate function
    basic_ostream& operator<<(unsigned short __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:209:20: note: candidate function
    basic_ostream& operator<<(int __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:206:20: note: candidate function
    basic_ostream& operator<<(bool __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:207:20: note: candidate function
    basic_ostream& operator<<(short __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:210:20: note: candidate function
    basic_ostream& operator<<(unsigned int __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:211:20: note: candidate function
    basic_ostream& operator<<(long __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:212:20: note: candidate function
    basic_ostream& operator<<(unsigned long __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:213:20: note: candidate function
    basic_ostream& operator<<(long long __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:214:20: note: candidate function
    basic_ostream& operator<<(unsigned long long __n);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:215:20: note: candidate function
    basic_ostream& operator<<(float __f);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:216:20: note: candidate function
    basic_ostream& operator<<(double __f);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:217:20: note: candidate function
    basic_ostream& operator<<(long double __f);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:788:1: note: candidate function [with _Traits = std::__1::char_traits<char>]
operator<<(basic_ostream<char, _Traits>& __os, char __c)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:755:1: note: candidate function [with _CharT = char, _Traits = std::__1::char_traits<char>]
operator<<(basic_ostream<_CharT, _Traits>& __os, char __cn)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:795:1: note: candidate function [with _Traits = std::__1::char_traits<char>]
operator<<(basic_ostream<char, _Traits>& __os, signed char __c)
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:802:1: note: candidate function [with _Traits = std::__1::char_traits<char>]
operator<<(basic_ostream<char, _Traits>& __os, unsigned char __c)
```

Possible solutions:
1) This proposed change. However, I'm not sure about header file where to define the `operator<<`. in `UIEvent.h` or new header file?
2) Defining same method for `KeySymbol` in `KeyEvent.h` and `ButtonMask` in `PointerEvent.h`, e.g.
```c++
std::ostream& operator<<(std::ostream& os, const ButtonMask& obj)
{
    os << static_cast<std::underlying_type<ButtonMask>::type>(obj);
    return os;
}
```
3) Calling `static_cast` in corresponding `apply()` methods

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Executed sample programs on macOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
