### PR TITLE
using std::optional in favor of bool return

### DIFF
--- a/include/vsg/core/Object.h
+++ b/include/vsg/core/Object.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <atomic>
 #include <string>
+#include <optional>
 
 #include <vsg/core/Export.h>
 #include <vsg/core/ref_ptr.h>
@@ -76,7 +77,7 @@ namespace vsg
         void setValue(const std::string& key, const char* value) { setValue(key, value ? std::string(value) : std::string()); }
 
         template<typename T>
-        bool getValue(const std::string& key, T& value) const;
+        std::optional<T> getValue(const std::string& key) const;
 
         void setObject(const std::string& key, Object* object);
         Object* getObject(const std::string& key);

--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -106,19 +106,18 @@ namespace vsg
     }
 
     template<typename T>
-    bool Object::getValue(const std::string& key, T& value) const
+    std::optional<T> Object::getValue(const std::string& key) const
     {
         using ValueT = Value<T>;
         const Object* object = getObject(key);
         if (object && (typeid(*object) == typeid(ValueT)))
         {
             const ValueT* vo = static_cast<const ValueT*>(getObject(key));
-            value = *vo;
-            return true;
+            return *vo;
         }
         else
         {
-            return false;
+            return {};
         }
     }
 

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -30,7 +30,7 @@ using namespace vsg;
 
 ObjectFactory::ObjectFactory()
 {
-    _createMap["nulltr"] = []() { return ref_ptr<Object>(); };
+    _createMap["nullptr"] = []() { return ref_ptr<Object>(); };
 
     VSG_REGISTER_new(vsg::Object);
 


### PR DESCRIPTION
# Pull Request Template

## Description

Utilizing std::optional rather than a bool check for returning a user value. This allows the library to transform code from:
```
int value;
if(object->getValue("foo", value))
{
}
```
Into its c++17 equivalent:
```
auto value = object->getValue("foo");
if(value)
{
}
```

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
