### PR TITLE
Added NOMINMAX macro definition

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -14,6 +14,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #define VK_USE_PLATFORM_WIN32_KHR
 
+#ifndef NOMINMAX
+#    define NOMINMAX
+#endif
+
 #include <vsg/viewer/Window.h>
 #include <vsg/ui/KeyEvent.h>
 #include <vsg/ui/PointerEvent.h>


### PR DESCRIPTION
# Pull Request Template

## Description

Without this macro, there are following errors in VS:

```bash
...\vsg\src\include\vsg/viewer/Window.h(156): warning C4003: not enough arguments for function-like macro invocation 'max'
1>...\vsg\src\include\vsg/viewer/Window.h(156): error C2589: '(': illegal token on right side of '::'
1>...\vsg\src\include\vsg/viewer/Window.h(156): error C2059: syntax error: ')'
1>...\vsg\src\include\vsg/viewer/Window.h(156): error C2062: type 'unknown-type' unexpected
1>...\vsg\src\include\vsg/viewer/Window.h(219): fatal error C1903: unable to recover from previous error(s); stopping compilation
```

Since we already in `platform/win32/Win32_Window.h`, I skipped the `ifdef _WIN32` guard
## Type of change

[x] Compiler error

## How Has This Been Tested?

Compiling `vsg`, `osg2vsg` and running `vsgExamples` in RELEASE/DEBUG configurations on Windows10, 64-bit version, using CMake v 3.13.3 and VS Community Edition 2017 v15.9.6