### PR TITLE
Make StateSet funcs virtual for example purposes, typo on the popFrom

### DIFF
--- a/include/vsg/nodes/StateGroup.h
+++ b/include/vsg/nodes/StateGroup.h
@@ -47,7 +47,7 @@ namespace vsg
 
         using StateComponents = std::vector<ref_ptr<StateComponent>>;
 
-        inline void compile(Context& context)
+        virtual void compile(Context& context)
         {
             for(auto& component : _stateComponents)
             {
@@ -55,7 +55,7 @@ namespace vsg
             }
         }
 
-        inline void pushTo(State& state) const
+        virtual void pushTo(State& state) const
         {
             for(auto& component : _stateComponents)
             {
@@ -63,11 +63,11 @@ namespace vsg
             }
         }
 
-        inline void popFrom(State& state) const
+        virtual void popFrom(State& state) const
         {
             for(auto& component : _stateComponents)
             {
-                component->pushTo(state);
+                component->popFrom(state);
             }
         }
 

--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -30,7 +30,7 @@ namespace vsg
         VkQueue graphicsQueue = 0;
 
         ref_ptr<DescriptorPool> descriptorPool;
-        ref_ptr<DescriptorSetLayout> descriptorSetLayout;
+        DescriptorSetLayouts descriptorSetLayouts;
         ref_ptr<PipelineLayout> pipelineLayout;
 
         ref_ptr<mat4Value> projMatrix;


### PR DESCRIPTION
# Pull Request Template

Mostly this commit is so my USE_DESCRIPTOR_STATESET define example will work in osg2vsg, but also spotted a small typo error.