### PR TITLE
Added descriptor read, write so dstBinding etc are serialised.

### DIFF
--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -38,6 +38,22 @@ namespace vsg
         uint32_t _dstArrayElement;
         VkDescriptorType _descriptorType;
 
+        void read(Input& input) override
+        {
+            Object::read(input);
+
+            _dstBinding = input.readValue<uint32_t>("DstBinding");
+            _dstArrayElement = input.readValue<uint32_t>("DstArrayElement");
+        }
+
+        void write(Output& output) const override
+        {
+            Object::write(output);
+
+            output.writeValue<uint32_t>("DstBinding", _dstBinding);
+            output.writeValue<uint32_t>("DstArrayElement", _dstArrayElement);
+        }
+
         // compile the Vulkan object, context parameter used for Device
         virtual void compile(Context& /*context*/) {}
 
@@ -206,7 +222,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Texture)
 
-        class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
+    class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
     {
     public:
         Uniform();
@@ -227,7 +243,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Uniform)
 
-        struct Material
+    struct Material
     {
         vec4 ambientColor;
         vec4 diffuseColor;

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -162,14 +162,14 @@ Texture::Texture() :
 
 void Texture::read(Input& input)
 {
-    Object::read(input);
+    Descriptor::read(input);
 
     _textureData = input.readObject<Data>("TextureData");
 }
 
 void Texture::write(Output& output) const
 {
-    Object::write(output);
+    Descriptor::write(output);
 
     output.writeObject("TextureData", _textureData.get());
 }
@@ -202,7 +202,7 @@ Uniform::Uniform() :
 
 void Uniform::read(Input& input)
 {
-    Object::read(input);
+    Descriptor::read(input);
 
     _dataList.resize(input.readValue<uint32_t>("NumData"));
     for (auto& data : _dataList)
@@ -213,7 +213,7 @@ void Uniform::read(Input& input)
 
 void Uniform::write(Output& output) const
 {
-    Object::write(output);
+    Descriptor::write(output);
 
     output.writeValue<uint32_t>("NumData", _dataList.size());
     for (auto& data : _dataList)


### PR DESCRIPTION
# Pull Request Template

## Description

Added a read and write method for Descriptor itself so _dstBinding and _dstArrayElement are serialised. With these changes the multi textured models are working correctly in vsgViewer as vsga files.

vsgViewer is working well on Windows platform.

- [x] Bug fix (non-breaking change which fixes an issue)

Tests

- [x] Serialised an fbx file with multi texturing to vsga format. Loaded in vsgViewer

