### PR TITLE
Added Orthographic projection. Exposed clear color

### DIFF
--- a/include/vsg/maths/transform.h
+++ b/include/vsg/maths/transform.h
@@ -99,6 +99,16 @@ namespace vsg
                          0, 0, -1, 0);
     }
 
+    // from vulkan cookbook
+    template<typename T>
+    constexpr t_mat4<T> orthographic(T left, T right, T bottom, T top, T zNear, T zFar)
+    {
+        return t_mat4<T>(2.0f / (right - left), 0.0f, 0.0f,  0.0f,
+                         0.0f, 2.0f / (bottom - top), 0.0f, 0.0f,
+                         0.0f, 0.0f, 1.0f / (zNear - zFar), 0.0f,
+                        -(right + left) / (right - left), -(bottom + top) / (bottom - top), zNear / (zNear - zFar), 1.0f);
+    }
+
     template<typename T>
     constexpr t_mat4<T> lookAt(t_vec3<T> const& eye, t_vec3<T> const& center, t_vec3<T> const& up)
     {

--- a/include/vsg/viewer/Camera.h
+++ b/include/vsg/viewer/Camera.h
@@ -55,6 +55,40 @@ namespace vsg
         double farDistance;
     };
 
+    class Orthographic : public Inherit<ProjectionMatrix, Orthographic>
+    {
+    public:
+        Orthographic() :
+            left(-1.0),
+            right(1.0),
+            bottom(-1.0),
+            top(1.0),
+            nearDistance(1.0),
+            farDistance(10000.0)
+        {
+        }
+
+        Orthographic(double l, double r, double b, double t, double nd, double fd) :
+            left(l),
+            right(r),
+            bottom(b),
+            top(t),
+            nearDistance(nd),
+            farDistance(fd)
+        {
+        }
+
+        void get(mat4& matrix) const override { matrix = orthographic(left, right, bottom, top, nearDistance, farDistance); }
+        void get(dmat4& matrix) const override { matrix = orthographic(left, right, bottom, top, nearDistance, farDistance); }
+
+        double left;
+        double right;
+        double bottom;
+        double top;
+        double nearDistance;
+        double farDistance;
+    };
+
     class ViewMatrix : public Inherit<Object, ViewMatrix>
     {
     public:

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -118,6 +118,9 @@ namespace vsg
 
         const VkExtent2D& extent2D() { return _extent2D; }
 
+        VkClearColorValue& clearColor() { return _clearColor; }
+        const VkClearColorValue& clearColor() const { return _clearColor; }
+
         Instance* instance() { return _instance; }
         const Instance* instance() const { return _instance; }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Orthoprojection only seems to work if left,right, and bottom,top are centered on origin so like -1,1,-1,1
0,1,0,1 doesn't work properly.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x ] Ortho projection used in vsginput example