### PR TITLE
Fixed updown arrows not returning correct code on Windows

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -42,7 +42,6 @@ namespace vsgWin32
 
             //bool rightSide = (lParam & 0x01000000) != 0;
             int virtualKey = ::MapVirtualKeyEx((lParam >> 16) & 0xff, 3, ::GetKeyboardLayout(0));
-
             auto itr = _keycodeMap.find(virtualKey);
             if (itr == _keycodeMap.end()) return false;
 
@@ -85,8 +84,6 @@ namespace vsgWin32
             char asciiKey[2];
             int numChars = ::ToAscii(static_cast<UINT>(wParam), (lParam>>16)&0xff, keyState, reinterpret_cast<WORD*>(asciiKey), 0);
             if (numChars>0) modifiedKeySymbol = (vsg::KeySymbol)asciiKey[0];
-
-            std::cout << "moded ascii: " << asciiKey[0] << "  0x" << std::hex << asciiKey[0] << std::endl;
 
             return true;
         }

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -143,6 +143,20 @@ KeyboardMap::KeyboardMap()
             {'Y', KEY_Y},
             {'Z', KEY_Z},
 
+            /* Cursor control & motion */
+
+            {VK_HOME, KEY_Home},
+            {VK_LEFT, KEY_Left},   /* Move left, left arrow */
+            {VK_UP, KEY_Up},       /* Move up, up arrow */
+            {VK_RIGHT, KEY_Right}, /* Move right, right arrow */
+            {VK_DOWN, KEY_Down},   /* Move down, down arrow */
+            {VK_PRIOR, KEY_Prior}, /* Prior, previous */
+            //{ VK_, KEY_Page_Up = 0xFF55,
+            {VK_NEXT, KEY_Next}, /* Next */
+            //KEY_Page_Down = 0xFF56,
+            {VK_END, KEY_End}, /* EOL */
+            //{ KEY_Begin = 0xFF58, /* BOL */
+
             {'!', KEY_Exclaim},
             {'"', KEY_Quotedbl},
             {'#', KEY_Hash},
@@ -181,20 +195,6 @@ KeyboardMap::KeyboardMap()
             //    KEY_Sys_Req = 0xFF15,
             {VK_ESCAPE, KEY_Escape},
             {VK_DELETE, KEY_Delete}, /* Delete, rubout */
-
-            /* Cursor control & motion */
-
-            {VK_HOME, KEY_Home},
-            {VK_LEFT, KEY_Left},   /* Move left, left arrow */
-            {VK_UP, KEY_Up},       /* Move up, up arrow */
-            {VK_RIGHT, KEY_Right}, /* Move right, right arrow */
-            {VK_DOWN, KEY_Down},   /* Move down, down arrow */
-            {VK_PRIOR, KEY_Prior}, /* Prior, previous */
-            //{ VK_, KEY_Page_Up = 0xFF55,
-            {VK_NEXT, KEY_Next}, /* Next */
-            //KEY_Page_Down = 0xFF56,
-            {VK_END, KEY_End}, /* EOL */
-            //{ KEY_Begin = 0xFF58, /* BOL */
 
             /* Misc Functions */
 
@@ -635,7 +635,6 @@ LRESULT Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam
         if (_keyboard->getKeySymbol(wParam, lParam, keySymbol, modifiedKeySymbol, keyModifier))
         {
             int repeatCount = (lParam & 0xffff);
-            std::cout << "Repeat count: " << repeatCount << std::endl;
             _bufferedEvents.emplace_back(new vsg::KeyPressEvent(this, event_time, keySymbol, modifiedKeySymbol, keyModifier, repeatCount));
         }
         break;


### PR DESCRIPTION
# Pull Request Template

Due to some overlap in the look up I've moved some of the virtual keys earlier in the look up. Should look at a better solution but this works for now


- [x] Bug fix (non-breaking change which fixes an issue)

## Testings

- [x] Tested in vsginput sample